### PR TITLE
Add support for integrated addresses + add verify_payment() function + Fix URI/QR codes

### DIFF
--- a/modules/monero/controllers/front/validation.php
+++ b/modules/monero/controllers/front/validation.php
@@ -62,4 +62,26 @@ class moneroValidationModuleFrontController extends ModuleFrontController
 		$rounded_amount = round($new_amount, 12); //the moneo wallet can't handle decimals smaller than 0.000000000001
 		return $rounded_amount;
 	}
+	
+	public function verify_payment($payment_id, $amount){
+      /* 
+       * function for verifying payments
+       * Check if a payment has been made with this payment id then notify the merchant
+       */
+       
+      $amount_atomic_units = $amount * 1000000000000;
+      $get_payments_method = $this->monero_daemon->get_payments($payment_id);
+      if(isset($get_payments_method["payments"][0]["amount"]))
+      { 
+		if($get_payments_method["payments"][0]["amount"] >= $amount_atomic_units)
+		{
+			$confirmed = true;
+		}  
+	  }
+	  else
+	  {
+		  $confirmed = false;
+	  }
+	  return $confirmed; 
+  }
 }

--- a/modules/monero/controllers/front/validation.php
+++ b/modules/monero/controllers/front/validation.php
@@ -13,6 +13,7 @@ class moneroValidationModuleFrontController extends ModuleFrontController
 		$amount = $this->changeto($total, $c);
 		$actual = $this->retriveprice($c);
 		$payment_id  = bin2hex(openssl_random_pseudo_bytes(8));
+		$uri = "monero:$address?amount=$amount?payment_id=$payment_id";
 		
 		$address = Configuration::get('MONERO_ADDRESS');
 		$daemon_address = Configuration::get('MONERO_WALLET');
@@ -26,6 +27,7 @@ class moneroValidationModuleFrontController extends ModuleFrontController
             'this_path_ssl'   => Tools::getShopDomainSsl(true, true) . __PS_BASE_URI__ . 'modules/' . $this->module->name . '/',
 				'address' => $address,
 				'amount' => $amount,
+				'uri' => $uri,
 				'integrated_address' => $integrated_address ));
 		$this->setTemplate('payment_box.tpl');
 	}

--- a/modules/monero/controllers/front/validation.php
+++ b/modules/monero/controllers/front/validation.php
@@ -1,7 +1,9 @@
 <?php
-//include(dirname(__FILE__). '/../../library.php'); This will be used later to connect to the wallet-rpc
+include(dirname(__FILE__). '/../../library.php');
 class moneroValidationModuleFrontController extends ModuleFrontController
 {
+	private $monero_daemon;
+
 	public function postProcess()
 	{
 		global $currency;
@@ -10,12 +12,21 @@ class moneroValidationModuleFrontController extends ModuleFrontController
 		$total = $cart->getOrderTotal();
 		$amount = $this->changeto($total, $c);
 		$actual = $this->retriveprice($c);
+		$payment_id  = bin2hex(openssl_random_pseudo_bytes(8));
+		
 		$address = Configuration::get('MONERO_ADDRESS');
+		$daemon_address = Configuration::get('MONERO_WALLET');
+		
+		$this->monero_daemon = new Monero_Library('http://'. $daemon_address .':2808/json_rpc');
+		
+		$integrated_address_method = $this->monero_daemon->make_integrated_address($payment_id);
+		$integrated_address = $integrated_address_method["integrated_address"];
 		
 		$this->context->smarty->assign(array(
             'this_path_ssl'   => Tools::getShopDomainSsl(true, true) . __PS_BASE_URI__ . 'modules/' . $this->module->name . '/',
 				'address' => $address,
-				'amount' => $amount ));
+				'amount' => $amount,
+				'integrated_address' => $integrated_address ));
 		$this->setTemplate('payment_box.tpl');
 	}
 	

--- a/modules/monero/views/templates/front/payment_box.tpl
+++ b/modules/monero/views/templates/front/payment_box.tpl
@@ -9,7 +9,7 @@
 						                                  <h3> Monero Payment Box</h3>
 					                               </div>
 					                           <div class='col-sm-3 col-md-3 col-lg-3'>
-						                          <img src='https://chart.googleapis.com/chart?cht=qr&chs=250x250&chl=" . $uri . "' class='img-responsive'>
+						                          <img src='https://chart.googleapis.com/chart?cht=qr&chs=250x250&chl= {$uri}' class='img-responsive'>
 					                           </div>
 					                           <div class='col-sm-9 col-md-9 col-lg-9' style='padding:10px;'>
 												   <p>Send {$amount} <b>XMR</b> to the following address:</p>

--- a/modules/monero/views/templates/front/payment_box.tpl
+++ b/modules/monero/views/templates/front/payment_box.tpl
@@ -9,11 +9,11 @@
 						                                  <h3> Monero Payment Box</h3>
 					                               </div>
 					                           <div class='col-sm-3 col-md-3 col-lg-3'>
-						                          <img src='https://chart.googleapis.com/chart?cht=qr&chs=250x250&chl= {$uri}' class='img-responsive'>
+						                          <img src='https://chart.googleapis.com/chart?cht=qr&chs=250x250&chl=" . $uri . "' class='img-responsive'>
 					                           </div>
 					                           <div class='col-sm-9 col-md-9 col-lg-9' style='padding:10px;'>
 												   <p>Send {$amount} <b>XMR</b> to the following address:</p>
-						                           <b></b><input type='text'  class='form-control' value='{$address}'>
+						                           <b></b><input type='text'  class='form-control' value='{$integrated_address}'>
                                                 <br></br>
                                                 <small>If you don't know how to use monero, <a href='#'>learn more here</a>. </small>
 					                           </div>


### PR DESCRIPTION
Adds the ability to connect to the monero-wallet-rpc and utilizes it to generate integrated addresses. Also adds a verify_payment() function that can be used to verify payments (though it still has to be decided how this will be implemented). This PR also fixes URIs/QR codes